### PR TITLE
Route command for OSX now works

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ host$ curl http://172.18.0.2
 
 To do the same on Mac OS X you can use:
 ```console
-host$ sudo route -nv -net 172.18.0.0/16 192.168.65.50
+host$ sudo route -nv add -net 172.18.0.0/16 192.168.65.50
 ```
 
 To SSH directly to the container you can use:


### PR DESCRIPTION
The route command for OSX didn't work for me using 10.11.5 (El Capitan). With the "add" keyword added to the command I got everything working just fine.