### PR TITLE
Add make test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,12 @@ clean: clean-certs clean-containers clean-slice ## Stops all containers and remo
 	$(RM) dcos-genconf.*.tar
 	$(RM) *.box
 
+test: ## executes the test script on a master
+	@docker exec -it $(MASTER_CTR)1 \
+		-e DCOS_PYTEST_DIR=$(DCOS_PYTEST_DIR) \
+		-e DCOS_PYTEST_CMD=$(DCOS_PYTEST_CMD) \
+		bash /opt/mesosphere/active/dcos-integration-test/run_integration_test.sh
+
 # Define the function to start a master or agent container. This also starts
 # docker and sshd in the resulting container, and makes sure docker started
 # successfully.

--- a/common.mk
+++ b/common.mk
@@ -21,6 +21,10 @@ endif
 
 DCOS_GENERATE_CONFIG_PATH := $(CURDIR)/dcos_generate_config.sh
 
+# Settings for test command
+DCOS_PYTEST_DIR := /opt/mesosphere/active/dcos-integration-test/
+DCOS_PYTEST_CMD := 'py.test -vv'
+
 # Variable for the registry host
 REGISTRY_HOST := registry.local
 


### PR DESCRIPTION
runs dcos integration tests, can customize
test commands with common.mk