### PR TITLE
improve guest time sync with host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,6 +29,8 @@ Vagrant.configure(2) do |config|
       v.memory = 8192
       # configure guest to use host DNS resolver
       v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
+      # guest should sync time if more than 10s off host
+      v.customize [ "guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 1000 ]
     end
   end
 end


### PR DESCRIPTION
Time in VirtualBox guest VM's can fall out of sync when the host machine is
suspended and resumed.  You can see this by suspending a host for a few
minutes, wake it up, and compare host and guest clocks.

It seems VirtualBox will not take action until 20min of drift is seen.  This
change will reduce the threshold to 10s.  Details here: http://stackoverflow.com/questions/19490652/how-to-sync-time-on-host-wake-up-within-virtualbox#19492466

The default value can't be seen but after setting, you can do this to see it:

        $ VBoxManage guestproperty get dcos-docker "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold"
        Value: 10000