### PR TITLE
Add `vagrant` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := all
 include common.mk
 
-.PHONY: all build build-all start postflight master agent public_agent installer genconf registry open-browser preflight deploy clean clean-certs clean-containers clean-slice
+.PHONY: all vagrant build build-all start postflight master agent public_agent installer genconf registry open-browser preflight deploy clean clean-certs clean-containers clean-slice
 
 # Set the number of DC/OS masters.
 MASTERS := 1
@@ -65,6 +65,10 @@ HOME_MOUNTS := \
 	-v $(HOME):$(HOME):ro
 
 all: install info ## Runs a full deploy of DC/OS in containers.
+
+vagrant:
+	vagrant up
+	vagrant ssh -c 'cd /vagrant && make'
 
 info: ips ## Provides information about the master and agent's ips.
 	@echo "Master IP: $(MASTER_IPS)"


### PR DESCRIPTION
```
$ make vagrant
vagrant up
Bringing machine 'dcos-docker' up with 'virtualbox' provider...
==> dcos-docker: Checking if box 'mesosphere/dcos-centos-virtualbox' is up to date...
==> dcos-docker: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> dcos-docker: flag to force provisioning. Provisioners marked to run always will still run.
vagrant ssh -c 'cd /vagrant && make'
centos-7 -> FROM centos:7
coreos -> FROM jess/coreos
debian-jessie -> FROM debian:jessie
fedora-23 -> FROM fedora:23
ubuntu-xenial -> FROM ubuntu:xenial
+ Building the centos-7 base image
...
Creating directories under /etc/mesosphere
Creating role file for slave_public
Configuring DC/OS
Setting and starting DC/OS
Created symlink from /etc/systemd/system/multi-user.target.wants/dcos-setup.service to /etc/systemd/system/dcos-setup.service.
DC/OS node setup in progress. Run 'make postflight' to block until they are ready.
Master IP: 172.17.0.2
Agent IP:  172.17.0.3
Public Agent IP:  172.17.0.4
Web UI: http://172.17.0.2
Connection to 127.0.0.1 closed.
```