### PR TITLE
cd /vagrant on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,6 @@ DC/OS Docker is designed to optimize developer cycle time. For a more production
     vagrant ssh
     ```
 
-1. Change into the mounted repo directory
-
-    ```console
-    cd /vagrant
-    ```
-
 ## Deploy
 
 1. Deploy DC/OS in Docker

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,5 +30,8 @@ Vagrant.configure(2) do |config|
       # configure guest to use host DNS resolver
       v.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     end
+
+    # Change home directory of "vagrant" user to /vagrant
+    vm_cfg.vm.provision :shell, inline: "grep -q 'cd /vagrant' ~/.bash_profile || echo -e '\n[ -d /vagrant ] && cd /vagrant' >> ~/.bash_profile", privileged: false
   end
 end


### PR DESCRIPTION
so that all the `make` commands work right away on login.

Note that a simple `usermod --home=/vagrant vagrant` doesn't work
because the `vagrant` user is logged in; `usermod` disallows that.