### PR TITLE
[DCOS-14929] Make resize step non-optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,16 @@ DC/OS Docker is designed to optimize developer cycle time. For a more production
     vagrant plugin install vagrant-vbguest
     ```
 
-1. (Optional) Resize the vagrant disk
+1. Bring up the Virtual Machine with a chosen disk size
 
-    DC/OS should deploy with the default disk size of 10GB, but for larger deployments you may need to increase the size of the VM.
+	Vagrant disks are sparse and as such they will only use the size that is actually used.
+
+    DC/OS should deploy with a size of 100GB, but for larger deployments you may need to increase the size of the VM.
 
     The first argument is the desired disk size in MB (ex: 102400 is 100GB).
 
     ```console
     vagrant/resize-disk.sh 102400
-    ```
-
-1. Bring up the virtual machine
-
-    ```console
-    vagrant up
     ```
 
 1. SSH into the virtual machine


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-14929

Please see the JIRA issue for the motivation behind this change.

## Design decisions

My understanding is that there are multiple options for this fix:

* Resize the disk as part of the Vagrant setup, using the [`vagrant-disksize` plugin](https://github.com/sprotheroe/vagrant-disksize).
* Somehow change the base box to have a disk larger than 10GB.
* Remove the text which says that 10GB should be enough and a resize is optional.

It appears that this plugin simply does not work at all, at least in this context. I am happy to try and debug this if a reviewer deems it worthwhile.

I'm not sure how to modify the base box and I didn't want to look into it before a reviewer said that this is the best option.

## Testing

### Manual

This change has been manually tested.
I ran the steps documented in the JIRA issue.

I am not sure what, if anything, is the problem with having a disk which is too large, and therefore I went with 100GB.

### Automated

Ideally, this would come with a CI change which tests the Vagrant box with a script that replicates the documentation. If a reviewer would like this, I'm happy to work on that but I believe that it would be a significant chunk of work. Also, in my experience testing the Vagrant setup of https://github.com/ClusterHQ/flocker, I learned that Vagrant is not particularly friendly with CI systems.

My personal preference is that we trust that issues will be found manually, at least until that bites us.