### PR TITLE
Remove 1.8.2 workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ DC/OS Docker is designed to optimize developer cycle time. For a more production
 
 - Because of Docker-in-Docker, DC/OS services (like Jenkins) that themselves use Docker-in-Docker may not work correctly.
 - Because containerization does not affect resource detection tools, each DC/OS node will think it can allocate all of the host's resources, leading to over-subscription without protection. You are still bound by the disk and memory constraints of the host, even if DC/OS thinks you have N (number of agent nodes) times more. Running Docker in a VM can protect your host from this and allows you to designate how much disk/memory/cpu DC/OS gets in total. Running Docker directly on a Linux host gives DC/OS more resources to play with but may also freeze your machine if you run too many DC/OS services/jobs.
-- DC/OS 1.8.2 introduced [a bug](https://github.com/dcos/dcos/commit/3a793ac4d0275a1cff1d6af380148fa7153392f0) that makes it incompatible with dcos-docker. Use DC/OS 1.8.1 or master until 1.8.3 is released.
 
 ## Requirements
 


### PR DESCRIPTION
It is definitely incorrect to say "until 1.8.3 is released". Possibly the best solution is to say to avoid 1.8.2. However, since there have been multiple releases since 1.8.2, I believe that it is best to just remove this point. AFAIK, there is no testing of each change to this repository to verify that new setups work with every old version of DC/OS, and so I can imagine that there are other old versions of DC/OS which either do not work or will not work at some point in the future.