### PR TITLE
rm dcos-genconf.*.tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ registry: $(CLIENT_CERT) ## Start a docker registry with certs in the mesos mast
 	@echo -e "\t$(REGISTRY_IP)"
 
 genconf: start $(CONFIG_FILE) ## Run the DC/OS installer with --genconf.
+	$(RM) dcos-genconf.*.tar ## Remove tar files from previous runs;  otherwise we might skip building Docker image
 	@echo "+ Running genconf"
 	@bash $(DCOS_GENERATE_CONFIG_PATH) --genconf --offline -v
 


### PR DESCRIPTION
in `genconf` target so that artifacts from previous runs don't cause errors like:

```
+ Running genconf
Unable to find image 'mesosphere/dcos-genconf:0ce03387884523f026-58fd0833ce81b6244f' locally
Pulling repository docker.io/mesosphere/dcos-genconf
docker: Error: image mesosphere/dcos-genconf not found.
See 'docker run --help'.
make: *** [genconf] Error 125
```

Cc: @karlkfi 