### PR TITLE
Use 10.0.2.3 as resolver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,8 +354,7 @@ master_list:
 - $(subst ${space},${newline} ,$(MASTER_IPS))
 process_timeout: 10000
 resolvers:
-- 8.8.8.8
-- 8.8.4.4
+- 10.0.2.3
 ssh_port: 22
 ssh_user: root
 superuser_password_hash: $(SUPERUSER_PASSWORD_HASH)


### PR DESCRIPTION
instead of Google DNS

because Google DNS won't work on every network environment, but 10.0.2.3
is VirtualBox's DNS, which is more likely to work.

Without this, my containers don't have outbound network connectivity,
because it seems that my network is blocking Google DNS.

Cc: @karlkfi 