### PR TITLE
Set up dcos-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ packer_cache
 *.box
 output-virtualbox-ovf
 .idea
+.dcos

--- a/Makefile
+++ b/Makefile
@@ -64,13 +64,24 @@ CERT_MOUNTS := \
 HOME_MOUNTS := \
 	-v $(HOME):$(HOME):ro
 
-all: install info ## Runs a full deploy of DC/OS in containers.
+all: install dcos-cli-config info  ## Runs a full deploy of DC/OS in containers.
 
 info: ips ## Provides information about the master and agent's ips.
 	@echo "Master IP: $(MASTER_IPS)"
 	@echo "Agent IP:  $(AGENT_IPS)"
 	@echo "Public Agent IP:  $(PUBLIC_AGENT_IPS)"
 	@echo "Web UI: http://$(firstword $(MASTER_IPS))"
+
+dcos-cli-config: ips
+	curl -sS https://bootstrap.pypa.io/get-pip.py | sudo python ;\
+	sudo pip install dcoscli ;\
+	if ! dcos config show core.dcos_url > /dev/null 2>&1; then \
+	    dcos config set core.dcos_url http://$(firstword $(MASTER_IPS)) ;\
+	fi ;\
+	echo "DCOS_CONFIG = $${DCOS_CONFIG}" ;\
+	dcos config show ;\
+	mkdir -p /vagrant/.dcos/ ;\
+	cp ~/.dcos/dcos.toml /vagrant/.dcos/
 
 open-browser: ips ## Opens your browser to the master ip.
 	$(OPEN_CMD) "http://$(firstword $(MASTER_IPS))"

--- a/envrc.sample
+++ b/envrc.sample
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# If you use [direnv](http://direnv.net), then you might want to copy this file
+# to `.envrc` and then do `direnv allow`.
+#
+# This will ensure that your [dcos-cli](https://github.com/dcos/dcos-cli/)
+# always points to your dcos-vagrant cluster, when you are in this directory.
+
+if which dcos > /dev/null 2>&1; then
+    export DCOS_CONFIG=$(pwd)/.dcos/dcos.toml
+    if ! dcos config show core.dcos_url > /dev/null 2>&1; then
+        dcos config set core.dcos_url http://m1.dcos
+    fi
+    echo "DCOS_CONFIG = ${DCOS_CONFIG}"
+    dcos config show
+fi
+
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=sh


### PR DESCRIPTION
This sets up [dcos-cli](https://github.com/dcos/dcos-cli) in the Vagrant VM:

```
[vagrant@dcos-docker vagrant]$ make postflight
Polling web server (900s timeout)...
Polling component status (800s timeout)...
DC/OS Healthy
[vagrant@dcos-docker vagrant]$ dcos node

Please go to the following link in your browser:

    http://172.17.0.2/login?redirect_uri=urn:ietf:wg:oauth:2.0:oob

Enter OpenID Connect ID Token: <token>
 HOSTNAME       IP                         ID
172.17.0.3  172.17.0.3  8ae9ff49-c45b-4edc-891f-8f9f2e8a2407-S0
172.17.0.4  172.17.0.4  8ae9ff49-c45b-4edc-891f-8f9f2e8a2407-S1
```

It also provides a sample `.envrc` that you can use so if you have [direnv](http://direnv.net) and [dcos-cli](https://github.com/dcos/dcos-cli) installed on your host system, you are configured to use dcos-cli there:

```
$ cp envrc.sample .envrc
direnv: error .envrc is blocked. Run `direnv allow` to approve its content.

$ direnv allow
direnv: loading .envrc
DCOS_CONFIG = /Users/abramowi/dev/git-repos/dcos-docker/.dcos/dcos.toml
core.dcos_acs_token ********
core.dcos_url http://172.17.0.2
direnv: export +DCOS_CONFIG

$ dcos node
Authentication failed. Please run `dcos auth login`

$ dcos auth login
If your browser didn't open, please go to the following link:

    http://172.17.0.2/login?redirect_uri=urn:ietf:wg:oauth:2.0:oob

Enter OpenID Connect ID Token: <token>
Login successful!

$ dcos node
 HOSTNAME       IP                         ID
172.17.0.3  172.17.0.3  8ae9ff49-c45b-4edc-891f-8f9f2e8a2407-S0
172.17.0.4  172.17.0.4  8ae9ff49-c45b-4edc-891f-8f9f2e8a2407-S1
```

Cc: @karlkfi, @tamarrow 