### PR TITLE
[DCOS-15322] Change postflight command to work on both DCOS/OSS and DCOS/E

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,7 @@ CURL_CMD="curl \
 	--location \
 	--max-redir 0 \
 	--silent "
-CMD=$CURL_CMD" http://127.0.0.1/ || "$CURL_HTTP_COMMAND" https://127.0.0.1/"
+CMD=$CURL_CMD" http://127.0.0.1/ || "$CURL_CMD" https://127.0.0.1/"
 echo "Polling web server ($${TIMEOUT_SECONDS}s timeout)..." >&2
 await
 if [[ -e "/opt/mesosphere/bin/3dt" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -385,20 +385,7 @@ function await() {
         exit $${RETCODE}
     fi
 }
-
-# Some security settings require HTTP and others require HTTPS.
-# Therefore we test both HTTP and HTTPS.
-CURL_CMD="curl \
-	--insecure \
-	--fail \
-	--location \
-	--max-redir 0 \
-	--silent "
-HTTP_ADDRESS="http://127.0.0.1/"
-HTTPS_ADDRESS="https://127.0.0.1/"
-HTTP_CMD=$${CURL_CMD}$${HTTP_ADDRESS}
-HTTPS_CMD=$${CURL_CMD}$${HTTPS_ADDRESS}
-CMD="eval "$${HTTP_CMD}" || "$${HTTPS_CMD}
+CMD="curl --insecure --fail --location --silent http://127.0.0.1/"
 echo "Polling web server ($${TIMEOUT_SECONDS}s timeout)..." >&2
 await
 if [[ -e "/opt/mesosphere/bin/3dt" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ function await() {
         exit $${RETCODE}
     fi
 }
-CMD="curl --fail --location --max-redir 0 --silent http://127.0.0.1/"
+CMD="curl --insecure --fail --location --max-redir 0 --silent https://127.0.0.1/"
 echo "Polling web server ($${TIMEOUT_SECONDS}s timeout)..." >&2
 await
 if [[ -e "/opt/mesosphere/bin/3dt" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -385,8 +385,10 @@ function await() {
         exit $${RETCODE}
     fi
 }
-1
-if echo $(CONFIG_BODY) | grep --silent "security: disabled" ; then
+
+# This is flaky because there are multiple ways that we can define
+# security: disabled in the config (e.g. no whitespace).
+if echo "$(CONFIG_BODY)" | grep --silent "security: disabled" ; then
 	ADDRESS=http://127.0.0.1/
 else
 	ADDRESS=https://127.0.0.1/

--- a/Makefile
+++ b/Makefile
@@ -385,13 +385,20 @@ function await() {
         exit $${RETCODE}
     fi
 }
+1
+if echo $(CONFIG_BODY) | grep --silent "security: disabled" ; then
+	ADDRESS=http://127.0.0.1/
+else
+	ADDRESS=https://127.0.0.1/
+fi
+
 CURL_CMD="curl \
 	--insecure \
 	--fail \
 	--location \
 	--max-redir 0 \
 	--silent "
-CMD=$CURL_CMD" http://127.0.0.1/ || "$CURL_CMD" https://127.0.0.1/"
+CMD=$${CURL_CMD}" "$${ADDRESS}
 echo "Polling web server ($${TIMEOUT_SECONDS}s timeout)..." >&2
 await
 if [[ -e "/opt/mesosphere/bin/3dt" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -386,21 +386,19 @@ function await() {
     fi
 }
 
-# This is flaky because there are multiple ways that we can define
-# security: disabled in the config (e.g. no whitespace).
-if echo "$(CONFIG_BODY)" | grep --silent "security: disabled" ; then
-	ADDRESS=http://127.0.0.1/
-else
-	ADDRESS=https://127.0.0.1/
-fi
-
+# Some security settings require HTTP and others require HTTPS.
+# Therefore we test both HTTP and HTTPS.
 CURL_CMD="curl \
 	--insecure \
 	--fail \
 	--location \
 	--max-redir 0 \
 	--silent "
-CMD=$${CURL_CMD}" "$${ADDRESS}
+HTTP_ADDRESS="http://127.0.0.1/"
+HTTPS_ADDRESS="https://127.0.0.1/"
+HTTP_CMD=$${CURL_CMD}$${HTTP_ADDRESS}
+HTTPS_CMD=$${CURL_CMD}$${HTTPS_ADDRESS}
+CMD="eval "$${HTTP_CMD}" || "$${HTTPS_CMD}
 echo "Polling web server ($${TIMEOUT_SECONDS}s timeout)..." >&2
 await
 if [[ -e "/opt/mesosphere/bin/3dt" ]]; then

--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,13 @@ function await() {
         exit $${RETCODE}
     fi
 }
-CMD="curl --insecure --fail --location --max-redir 0 --silent https://127.0.0.1/"
+CURL_CMD="curl \
+	--insecure \
+	--fail \
+	--location \
+	--max-redir 0 \
+	--silent "
+CMD=$CURL_CMD" http://127.0.0.1/ || "$CURL_HTTP_COMMAND" https://127.0.0.1/"
 echo "Polling web server ($${TIMEOUT_SECONDS}s timeout)..." >&2
 await
 if [[ -e "/opt/mesosphere/bin/3dt" ]]; then


### PR DESCRIPTION
## High Level Description

This changes `make postflight` to work on DC/OS Enterprise.

## Related Issues

  - [DCOS-15322](https://jira.mesosphere.com/browse/DCOS-15322) DC/OS Docker - Postflight does not complete on DC/OS Enterprise.
  
## Testing

I have tested this by creating clusters with DC/OS Enterprise `master` and DC/OS OSS `master`. Both complete and the commands seem to work at the same time as the old command worked on OSS.

I would appreciate a reviewer doing a similar check to confirm.