### PR TITLE
[DCOS-15758] Fix broken test path and add comment about it not working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,10 +261,12 @@ clean: clean-certs clean-containers clean-slice ## Stops all containers and remo
 	$(RM) *.box
 
 test: ## executes the test script on a master
+	# This command is broken, as per
+	# https://jira.mesosphere.com/browse/DCOS-15759.
 	@docker exec -it \
 		$(MASTER_CTR)1 \
 		/bin/bash -x -c "\
-			cd /opt/mesosphere/active/dcos-integration-test/ && \
+			cd /opt/mesosphere/active/dcos-integration-test/util && \
 			/bin/bash ./run_integration_test.sh"
 
 # Define the function to start a master or agent container. This also starts


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-15758

Running this command now runs the integration test script.
As per the linked issue, the test running script does not work.
I think that it is useful to fix this because it can act as a smoke test to see if at least some parts of DC/OS Docker are working.
I recently made a change which seemed non-breaking and this would have caught it.

I have tested this by running `make` and then `make test`.