### PR TITLE
Remove Systemd requirement from DC/OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,9 +300,8 @@ docker run -dt --privileged \
 	$(DOCKER_IMAGE);
 sleep 2;
 docker exec $(1)$(2) mkdir -p /var/lib/dcos
-docker exec $(1)$(2) /bin/bash -c \
+docker exec $(1)$(2) /bin/bash -c -o errexit -o nounset -o pipefail \
     " \
-	set -o errexit -o nounset -o pipefail && \
 	echo 'MESOS_SYSTEMD_ENABLE_SUPPORT=$(MESOS_SYSTEMD_ENABLE_SUPPORT)' \
     	>> /var/lib/dcos/mesos-slave-common \
 	"

--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ master: ## Starts the containers for DC/OS masters.
 
 $(MESOS_SLICE):
 	@if [ "$(MESOS_SYSTEMD_ENABLE_SUPPORT)" == "true" ]; then \
-	    echo -e '[Unit]\nDescription=Mesos Executors Slice' | sudo tee -a $@; \
-	    sudo systemctl start mesos_executors.slice; \
+		echo -e '[Unit]\nDescription=Mesos Executors Slice' | sudo tee -a $@; \
+		sudo systemctl start mesos_executors.slice; \
 	fi
 
 
@@ -256,8 +256,8 @@ clean-containers: ## Removes and cleans up the master, agent, and installer cont
 
 clean-slice: ## Removes and cleanups up the systemd slice for the mesos executor.
 	@if [ "$(MESOS_SYSTEMD_ENABLE_SUPPORT)" == "true" ]; then \
-	    sudo systemctl stop mesos_executors.slice; \
-	    sudo rm -f $(MESOS_SLICE); \
+		sudo systemctl stop mesos_executors.slice; \
+		sudo rm -f $(MESOS_SLICE); \
 	fi
 
 clean: clean-certs clean-containers clean-slice ## Stops all containers and removes all generated files for the cluster.
@@ -304,9 +304,9 @@ docker run -dt --privileged \
 sleep 2;
 docker exec $(1)$(2) mkdir -p /var/lib/dcos
 docker exec $(1)$(2) /bin/bash -c -o errexit -o nounset -o pipefail \
-    " \
+	" \
 	echo 'MESOS_SYSTEMD_ENABLE_SUPPORT=$(MESOS_SYSTEMD_ENABLE_SUPPORT)' \
-    	>> /var/lib/dcos/mesos-slave-common \
+		>> /var/lib/dcos/mesos-slave-common \
 	"
 docker exec $(1)$(2) systemctl start sshd.service;
 docker exec $(1)$(2) docker ps -a > /dev/null;

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,11 @@ master: ## Starts the containers for DC/OS masters.
 	$(foreach NUM,$(shell seq 1 $(MASTERS)),$(call start_dcos_container,$(MASTER_CTR),$(NUM),$(MASTER_MOUNTS) $(TMPFS_MOUNTS) $(CERT_MOUNTS) $(HOME_MOUNTS) $(VOLUME_MOUNTS)))
 
 $(MESOS_SLICE):
-	@echo -e '[Unit]\nDescription=Mesos Executors Slice' | sudo tee -a $@
-	@sudo systemctl start mesos_executors.slice
+	@if [ "$(MESOS_SYSTEMD_ENABLE_SUPPORT)" == "true" ]; then \
+	    echo -e '[Unit]\nDescription=Mesos Executors Slice' | sudo tee -a $@; \
+	    sudo systemctl start mesos_executors.slice; \
+	fi
+
 
 agent: $(MESOS_SLICE) ## Starts the containers for DC/OS agents.
 	$(foreach NUM,$(shell seq 1 $(AGENTS)),$(call start_dcos_container,$(AGENT_CTR),$(NUM),$(TMPFS_MOUNTS) $(SYSTEMD_MOUNTS) $(CERT_MOUNTS) $(HOME_MOUNTS) $(VOLUME_MOUNTS)))

--- a/Makefile
+++ b/Makefile
@@ -301,8 +301,11 @@ docker run -dt --privileged \
 sleep 2;
 docker exec $(1)$(2) mkdir -p /var/lib/dcos
 docker exec $(1)$(2) /bin/bash -c \
-    "echo 'MESOS_SYSTEMD_ENABLE_SUPPORT=$(MESOS_SYSTEMD_ENABLE_SUPPORT)' \
-    >> /var/lib/dcos/mesos-slave-common"
+    " \
+	set -o errexit -o nounset -o pipefail \
+	echo 'MESOS_SYSTEMD_ENABLE_SUPPORT=$(MESOS_SYSTEMD_ENABLE_SUPPORT)' \
+    	>> /var/lib/dcos/mesos-slave-common \
+	"
 docker exec $(1)$(2) systemctl start sshd.service;
 docker exec $(1)$(2) docker ps -a > /dev/null;
 endef

--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ sleep 2;
 docker exec $(1)$(2) mkdir -p /var/lib/dcos
 docker exec $(1)$(2) /bin/bash -c \
     " \
-	set -o errexit -o nounset -o pipefail \
+	set -o errexit -o nounset -o pipefail && \
 	echo 'MESOS_SYSTEMD_ENABLE_SUPPORT=$(MESOS_SYSTEMD_ENABLE_SUPPORT)' \
     	>> /var/lib/dcos/mesos-slave-common \
 	"

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ SSH_KEY := $(SSH_DIR)/id_$(SSH_ALGO)
 
 # Variable for the path to the mesos executors systemd slice.
 MESOS_SLICE := /run/systemd/system/mesos_executors.slice
+# Running Mesos without systemd support is not supported by DC/OS.
+# Therefore, non-Linux DC/OS Docker hosts are experimental.
+MESOS_SYSTEMD_ENABLE_SUPPORT := true
 
 # Variables for various docker arguments.
 MASTER_MOUNTS :=
@@ -249,8 +252,10 @@ clean-containers: ## Removes and cleans up the master, agent, and installer cont
 	$(foreach NUM,$(shell seq 1 $(PUBLIC_AGENTS)),$(call remove_container,$(PUBLIC_AGENT_CTR),$(NUM)))
 
 clean-slice: ## Removes and cleanups up the systemd slice for the mesos executor.
-	@sudo systemctl stop mesos_executors.slice
-	@sudo rm -f $(MESOS_SLICE)
+	@if [ "$(MESOS_SYSTEMD_ENABLE_SUPPORT)" == "true" ]; then \
+	    sudo systemctl stop mesos_executors.slice; \
+	    sudo rm -f $(MESOS_SLICE); \
+	fi
 
 clean: clean-certs clean-containers clean-slice ## Stops all containers and removes all generated files for the cluster.
 	$(RM) $(CURDIR)/genconf/ssh_key
@@ -270,6 +275,13 @@ test: ## executes the test script on a master
 # Define the function to start a master or agent container. This also starts
 # docker and sshd in the resulting container, and makes sure docker started
 # successfully.
+#
+# A supported configuration includes systemd on the host. In these
+# configurations, Mesos uses systemd. There is experimentatl support for
+# running Mesos without systemd support. A configuration file which is common
+# to agents and public agents is either created or added to.
+# This configuration file specifies whether Mesos should or should not enable systemd.
+# This file path is referred to in the `dcos-mesos-slave.service` configuration.
 # @param name	  First part of the container name.
 # @param number	  ID of the container.
 # @param mounts	  Specific mounts for the container.
@@ -287,6 +299,10 @@ docker run -dt --privileged \
 	--add-host "$(REGISTRY_HOST):$(shell $(IP_CMD) $(MASTER_CTR)1 2>/dev/null || echo 127.0.0.1)" \
 	$(DOCKER_IMAGE);
 sleep 2;
+docker exec $(1)$(2) mkdir -p /var/lib/dcos
+docker exec $(1)$(2) /bin/bash -c \
+    "echo 'MESOS_SYSTEMD_ENABLE_SUPPORT=$(MESOS_SYSTEMD_ENABLE_SUPPORT)' \
+    >> /var/lib/dcos/mesos-slave-common"
 docker exec $(1)$(2) systemctl start sshd.service;
 docker exec $(1)$(2) docker ps -a > /dev/null;
 endef

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ DC/OS Docker is designed to optimize developer cycle time. For a more production
 
 ### Linux
 
-- systemd
+- systemd.
+  Or optionally see "systemd" for an experimental alternative.
 - make
 - Docker 1.13.1
 - A recent kernel that supports Overlay FS
@@ -173,6 +174,17 @@ want to test something else you can run:
 ```console
 $ make DISTRO=fedora
 ```
+
+### Not using `systemd` on the host
+
+By default, systemd is used on the host to create a [systemd
+slice](https://www.freedesktop.org/software/systemd/man/systemd.slice.html).
+This is the supported configuration.
+
+It is possible to run DC/OS Docker on hosts without systemd.  Set the variable
+`MESOS_SYSTEMD_ENABLE_SUPPORT` to `false` to disable systemd on the host. This
+changes a Mesos setting and is not supported by DC/OS. On non-Linux hosts this
+is the default setting.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This is the supported configuration.
 
 It is possible to run DC/OS Docker on hosts without systemd.  Set the variable
 `MESOS_SYSTEMD_ENABLE_SUPPORT` to `false` to disable systemd on the host. This
-changes a Mesos setting and is not supported by DC/OS.
+changes a Mesos setting. Although this setting works at the time of writing, it is not officially supported by DC/OS and so this feature is experimental.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ DC/OS Docker is designed to optimize developer cycle time. For a more production
 ### Linux
 
 - systemd.
-  Or optionally see "systemd" for an experimental alternative.
+  Or optionally see [here](#not-using-systemd-on-the-host) for an experimental alternative.
 - make
 - Docker 1.13.1
 - A recent kernel that supports Overlay FS
@@ -183,8 +183,7 @@ This is the supported configuration.
 
 It is possible to run DC/OS Docker on hosts without systemd.  Set the variable
 `MESOS_SYSTEMD_ENABLE_SUPPORT` to `false` to disable systemd on the host. This
-changes a Mesos setting and is not supported by DC/OS. On non-Linux hosts this
-is the default setting.
+changes a Mesos setting and is not supported by DC/OS.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ It is possible to run DC/OS Docker on hosts without systemd.  Set the variable
 `MESOS_SYSTEMD_ENABLE_SUPPORT` to `false` to disable systemd on the host. This
 changes a Mesos setting. Although this setting works at the time of writing, it is not officially supported by DC/OS and so this feature is experimental.
 
+One problem which may occur when not using `systemd` on the host is that executors and tasks will be killed when the agent is restarted. [A JIRA issue](https://jira.mesosphere.com/browse/DCOS_OSS-1131) tracks making it possible to run DC/OS Docker in a supported manner without `systemd`.
+
 ## Troubleshooting
 
 Oh dear, you must be in an unfortunate position. You have a few options with


### PR DESCRIPTION
## High Level Description

This enables and documents experimental support for running DC/OS Docker on without using systemd.

## Related Issues

https://jira.mesosphere.com/browse/DCOS-15862 - Add an option to run DC/OS Docker without systemd

This was taken out of https://github.com/dcos/dcos-docker/pull/36

## Testing on the Vagrant VM

I have spun up a cluster with `make` and seen that this works.
Some integration tests can be run on this cluster and as a sanity check,
the agent configuration file shows the expected data.

```
$ docker exec dcos-docker-pubagent1 cat /var/lib/dcos/mesos-slave-common
MESOS_SYSTEMD_ENABLE_SUPPORT=true
```

I have spun up a cluster with `make clean; make MESOS_SYSTEMD_ENABLE_SUPPORT=false`:

```
$ docker exec dcos-docker-pubagent1 cat /var/lib/dcos/mesos-slave-common
MESOS_SYSTEMD_ENABLE_SUPPORT=false
```

On each of the above, I ran the following commands to see that the cluster seems to work:

```
make postflight
docker exec -it dcos-docker-master1 /bin/bash
source /opt/mesosphere/environment.export
cd /opt/mesosphere/active/dcos-integration-test/
# Some tests are failing in 3dt on a standard configuration so just check
# if some tests can be run.
pytest test_auth.py
```

https://github.com/dcos/dcos-docker/pull/36 provides evidence that this works on a host without systemd (macOS).