### PR TITLE
Remove service file directory in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,7 @@ clean: clean-certs clean-containers clean-slice ## Stops all containers and remo
 	$(RM) -r $(SSH_DIR)
 	$(RM) -r $(SBIN_DIR)
 	$(RM) dcos-genconf.*.tar
+	$(RM) -r $(SERVICE_DIR)
 
 # Use SSH to execute tests because docker run/exec has a bug that breaks unbuffered pytest output.
 # https://github.com/moby/moby/issues/8755 - Fixed in Docker 17.06+


### PR DESCRIPTION
See https://jira.mesosphere.com/browse/DCOS-16002

I have tested this with `master` by running:

```sh
$ make DOCKER_STORAGEDRIVER=aufs
...
$ cat include/systemd/docker.service  | grep daemon
ExecStart=/usr/bin/docker daemon -D -s aufs --disable-legacy-registry=true --exec-opt=native.cgroupdriver=cgroupfs
$ make clean
...
$ cat include/systemd/docker.service  | grep daemon
ExecStart=/usr/bin/docker daemon -D -s aufs --disable-legacy-registry=true --exec-opt=native.cgroupdriver=cgroupfs
$ make DOCKER_STORAGEDRIVER=overlay
...
$ cat include/systemd/docker.service  | grep daemon
ExecStart=/usr/bin/docker daemon -D -s aufs --disable-legacy-registry=true --exec-opt=native.cgroupdriver=cgroupfs
```

Then with the proposed changes:

```sh
$ make clean
...
rm -f -r /Users/Adam/Documents/mesosphere/dcos/dcos-docker/include/systemd
$ cat include/systemd/docker.service  | grep daemon
ExecStart=/usr/bin/docker daemon -D -s overlay --disable-legacy-registry=true --exec-opt=native.cgroupdriver=cgroupfs
```