### PR TITLE
Bump docker version to support the overlay2 storage driver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM mesosphere/dcos-docker:base
 
-ENV DOCKER_VERSION 1.11.2
+ENV DOCKER_VERSION 1.13.1
 ENV TERM xterm
 ENV LANG en_US.UTF-8
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ The support for macOS as a host is experimental.
 > **NOTE:**  Docker for Mac support is experimental. Use Vagrant for a fully supported configuration.
 
 - [Docker for Mac](https://docs.docker.com/docker-for-mac/) 1.13.1+
-  - overlay or aufs storage driver (recommended). See [Storage Driver](#storage-driver) for more details.
   - 6GB Memory (recommended). See [Docker for Mac advanced config](https://docs.docker.com/docker-for-mac/#advanced) for more details.
 - make
 - git

--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ $ docker exec -it dcos-docker-master1 bash
 ## Storage Driver
 
 There is no requirement on the hosts storage driver type, but the docker daemon
-running inside docker container supports only `aufs` and `overlay`. The loopback
-devicemapper may be problematic when it comes to loopback devices - they may not
-be properly cleaned up and thus prevent docker daemon from starting. YMMV
-though.
+running inside docker container supports only `aufs`, `overlay`, and
+`overlay2`. The loopback devicemapper may be problematic when it comes to
+loopback devices - they may not be properly cleaned up and thus prevent docker
+daemon from starting. YMMV though.
 
 Unless user specifies the storage driver using `DOCKER_STORAGEDRIVER` env variable,
 the script tries to use the same one that the host uses. It detects it using
@@ -191,10 +191,6 @@ the script tries to use the same one that the host uses. It detects it using
 or the script will terminate.
 
 To check the current storage driver, use `docker info --format "{{json .Driver}}"`.
-
-On Docker for Mac, the default driver is `overlay2`, which is not supported.
-Therefore, it is necessary to either set `DOCKER_STORAGEDRIVER` or to change the
-host storage driver.
 
 To change the storage driver on Docker for Mac to `overlay`, go to Docker >
 Preferences > Daemon Advanced and add `"storage-driver" : "overlay"` to the

--- a/README.md
+++ b/README.md
@@ -191,10 +191,6 @@ or the script will terminate.
 
 To check the current storage driver, use `docker info --format "{{json .Driver}}"`.
 
-To change the storage driver on Docker for Mac to `overlay`, go to Docker >
-Preferences > Daemon Advanced and add `"storage-driver" : "overlay"` to the
-configuration file.  Then click "Apply & Restart".
-
 ## Settings
 
 ### Changing the number of masters or agents

--- a/common.mk
+++ b/common.mk
@@ -12,8 +12,8 @@ PUBLIC_AGENT_CTR := dcos-docker-pubagent
 INSTALLER_CTR := dcos-docker-installer
 DOCKER_IMAGE := mesosphere/dcos-docker
 
-# Variable to set the correct Docker graphdriver to the currently running
-# graphdriver. This makes docker in docker work more efficiently.
+# Variable to set the correct Docker soragedriver to the currently running
+# soragedriver. This makes docker in docker work more efficiently.
 DOCKER_STORAGEDRIVER := $(if $(DOCKER_STORAGEDRIVER),$(DOCKER_STORAGEDRIVER),$(shell docker info 2>/dev/null | grep "Storage Driver" | sed 's/.*: //'))
 ifneq ($(DOCKER_STORAGEDRIVER),$(filter $(DOCKER_STORAGEDRIVER),overlay aufs))
 $(error Only `overlay` and `aufs` storage drivers are supported for DinD. Please check README.md for details)

--- a/common.mk
+++ b/common.mk
@@ -15,7 +15,7 @@ DOCKER_IMAGE := mesosphere/dcos-docker
 # Variable to set the correct Docker soragedriver to the currently running
 # soragedriver. This makes docker in docker work more efficiently.
 DOCKER_STORAGEDRIVER := $(if $(DOCKER_STORAGEDRIVER),$(DOCKER_STORAGEDRIVER),$(shell docker info 2>/dev/null | grep "Storage Driver" | sed 's/.*: //'))
-ifneq ($(DOCKER_STORAGEDRIVER),$(filter $(DOCKER_STORAGEDRIVER),overlay aufs))
+ifneq ($(DOCKER_STORAGEDRIVER),$(filter $(DOCKER_STORAGEDRIVER),overlay aufs overlay2))
 $(error Only `overlay` and `aufs` storage drivers are supported for DinD. Please check README.md for details)
 endif
 

--- a/common.mk
+++ b/common.mk
@@ -12,8 +12,8 @@ PUBLIC_AGENT_CTR := dcos-docker-pubagent
 INSTALLER_CTR := dcos-docker-installer
 DOCKER_IMAGE := mesosphere/dcos-docker
 
-# Variable to set the correct Docker soragedriver to the currently running
-# soragedriver. This makes docker in docker work more efficiently.
+# Variable to set the correct Docker storage driver to the currently running
+# storage driver. This makes docker in docker work more efficiently.
 DOCKER_STORAGEDRIVER := $(if $(DOCKER_STORAGEDRIVER),$(DOCKER_STORAGEDRIVER),$(shell docker info 2>/dev/null | grep "Storage Driver" | sed 's/.*: //'))
 ifneq ($(DOCKER_STORAGEDRIVER),$(filter $(DOCKER_STORAGEDRIVER),overlay aufs overlay2))
 $(error Only `overlay` and `aufs` storage drivers are supported for DinD. Please check README.md for details)


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-1202 - Support the overlay2 storage driver on DC/OS Docker

Given that the aim of this is to get overlay2, I chose to upgrade to version 1.13.1 for multiple reasons:
* It was simple to change the version number and this is the latest version with that property I believe
* This matches the currently documented minimum version of the Docker client. I'm not sure if there are conflicts with using newer daemons.

I have tested this by running {{make}} on a Mac with the overlay2 storage driver. {{make}} and {{make postflight}} both complete.