### PR TITLE
[DCOS_OSS-1203] Allow setting the port of the installer container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,15 +240,15 @@ registry: $(CLIENT_CERT) ## Start a docker registry with certs in the mesos mast
 genconf: start $(CONFIG_FILE) ## Run the DC/OS installer with --genconf.
 	$(RM) dcos-genconf.*.tar ## Remove tar files from previous runs;  otherwise we might skip building Docker image
 	@echo "+ Running genconf"
-	@bash $(DCOS_GENERATE_CONFIG_PATH) --genconf --offline -v
+	@export PORT=${INSTALLER_PORT}; bash $(DCOS_GENERATE_CONFIG_PATH) --genconf --offline -v
 
 preflight: genconf ## Run the DC/OS installer with --preflight.
 	@echo "+ Running preflight"
-	@bash $(DCOS_GENERATE_CONFIG_PATH) --preflight --offline -v
+	@export PORT=${INSTALLER_PORT}; bash $(DCOS_GENERATE_CONFIG_PATH) --preflight --offline -v
 
 deploy: preflight ## Run the DC/OS installer with --deploy.
 	@echo "+ Running deploy"
-	@bash $(DCOS_GENERATE_CONFIG_PATH) --deploy --offline -v
+	@export PORT=${INSTALLER_PORT}; bash $(DCOS_GENERATE_CONFIG_PATH) --deploy --offline -v
 
 install: VOLUME_MOUNTS += $(BOOTSTRAP_VOLUME_MOUNT)
 install: genconf ## Install DC/OS using "advanced" method
@@ -262,7 +262,7 @@ install: genconf ## Install DC/OS using "advanced" method
 
 web: preflight ## Run the DC/OS installer with --web.
 	@echo "+ Running web"
-	@bash $(DCOS_GENERATE_CONFIG_PATH) --web --offline -v
+	@export PORT=${INSTALLER_PORT}; bash $(DCOS_GENERATE_CONFIG_PATH) --web --offline -v
 
 clean-certs: ## Remove all the certs generated for the registry.
 	$(RM) -r $(CERTS_DIR)

--- a/common.mk
+++ b/common.mk
@@ -10,6 +10,7 @@ MASTER_CTR:= dcos-docker-master
 AGENT_CTR := dcos-docker-agent
 PUBLIC_AGENT_CTR := dcos-docker-pubagent
 INSTALLER_CTR := dcos-docker-installer
+INSTALLER_PORT := 9000
 DOCKER_IMAGE := mesosphere/dcos-docker
 
 # Variable to set the correct Docker graphdriver to the currently running


### PR DESCRIPTION
When starting multiple clusters simultaneously, there is a chance we get multiple installer containers simultaneously.

There are currently two conflicts which prevent this from working:
* Installer container names
* Installer container ports

I am working on container names in separate branches.
With the WIP fixes for container name collisions, I get:

> Bind for 0.0.0.0:9000 failed: port is already allocated

With the changes proposed here, I do not get these errors.