### PR TITLE
Use the given password in the config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ ifeq ($(HAVE_TTY), 1)
 	INTERACTIVE += -t
 endif
 
+SUPERUSER_PASSWORD_HASH_CMD := $(INSTALLER_CMD) --hash-password $(SUPERUSER_PASSWORD) | tail -1
+
 all: install info ## Runs a full deploy of DC/OS in containers.
 
 vagrant:
@@ -460,7 +462,7 @@ resolvers:
 - $(subst ${space},${newline} ,$(RESOLVERS))
 ssh_port: 22
 ssh_user: root
-superuser_password_hash: $(SUPERUSER_PASSWORD_HASH)
+superuser_password_hash: $(shell $(SUPERUSER_PASSWORD_HASH_CMD))
 superuser_username: $(SUPERUSER_USERNAME)
 platform: docker
 check_time: false

--- a/common.mk
+++ b/common.mk
@@ -1,9 +1,9 @@
 SHELL := /bin/bash
 
-# Set the superuser username
+# Set the superuser username and password
+# These are only used for DC/OS Enterprise.
 SUPERUSER_USERNAME := admin
 SUPERUSER_PASSWORD := admin
-SUPERUSER_PASSWORD_HASH := $$6$$rounds=656000$$5hVo9bKXfWRg1OCd$$3X2U4hI6RYvKFqm6hXtEeqnH2xE3XUJYiiQ/ykKlDXUie/0B6cuCZEfLe.dN/7jF5mx/vSkoLE5d1Zno20Z7Q0
 
 # Variables for the resulting container & image names.
 MASTER_CTR:= dcos-docker-master


### PR DESCRIPTION
See https://jira.mesosphere.com/browse/DCOS-16035.

This makes it possible to set the `DCOS_SUPERUSER_PASSWORD` for an enterprise cluster without hashing the password yourself.

I have tested this by creating a cluster and then using the DC/OS CLI as follows:

```
dcos cluster setup http://172.17.0.2 --username admin --password <my_password> --no-check
```

Authentication succeeds.

This makes overriding the hash manually a little more complex - maybe the override command needs to include "echo". There may be ways to fix this, like having the command look at the environment for an existing variable, but I think that this complexity can be added when the feature is requested.

This shouldn't be worked out at the time of the variable definition as it is a slow process (a few seconds) and it is not necessary for e.g. `make clean`.