### PR TITLE
refactor dcos-postflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -470,6 +470,8 @@ endef
 # Define the postflight script to wait until DC/OS is up and running
 define DCOS_POSTFLIGHT_BODY
 #!/usr/bin/env bash
+shopt -s nullglob
+
 # Run the DC/OS diagnostic script for up to the specified number of seconds to ensure
 # we do not return ERROR on a cluster that hasn't fully achieved quorum.
 TIMEOUT_SECONDS="$${1:-900}"
@@ -496,9 +498,11 @@ elif [[ -e "/opt/mesosphere/bin/3dt" ]]; then
     # 3dt --diag will complain about missing endpoints_config.json if not
     # passed explicitly. This error is not influencing the diagnostics status.
     # This is a bug, which has been fixed in DC/OS >= 1.10
-    cfg_files=( /opt/mesosphere/packages/3dt*/endpoints_config.json )
+    cfg_files=( /opt/mesosphere/etc/dcos-3dt-endpoint-config*.json )
+    cfg_files+=( /opt/mesosphere/endpoints_config*.json )
+    cfg_files+=( /opt/mesosphere/etc/endpoints_config*.json )
     if [ $${#cfg_files[@]} -gt 0 ]; then
-        CMD="$${CMD} -endpoint-config=$${cfg_files[0]}"
+        CMD="$${CMD} --endpoint-config=$${cfg_files[0]}"
     fi
 elif [[ -e "/opt/mesosphere/bin/dcos-diagnostics.py" ]]; then
     # DC/OS <= 1.6


### PR DESCRIPTION
 - add `shopt -s nullglob` flag to ignore the config files that were not
  found in `cfg_files`

 - add extra locations for endpoint config. Different versions of 3dt are
   using endpoint config from various locations. Using an array to try all of
   them.