### PR TITLE
Force sequential execution of make rules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+# Since this Makefile was not designed with parallel execution in mind, opt
+# out of any parallelism users might enable have via the `make` invocation.
+.NOTPARALLEL:
+
 .DEFAULT_GOAL := all
 include common.mk
 


### PR DESCRIPTION
The current Makefile was not written with parallel jobs in mind; instead
all rules are expected to be executed sequentially.

Make this explicit in the Makefile.