### PR TITLE
Fixed instructions for forcing dcos-docker to use `docker 1.13.1`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ is not supported by Docker 1.11.2 (the default version in the "node" containers)
 also specify a newer version of Docker to use in the "node" containers:
 
 ```
-make DOCKER_STORAGEDRIVER=overlay2 DOCKER=1.13.1
+make DOCKER_STORAGEDRIVER=overlay2 DOCKER_VERSION=1.13.1
 ```
 
 Alternatively, Docker itself can be configured to use `overlay`.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcos/dcos-docker/57)
<!-- Reviewable:end -->
