### PR TITLE
make test: expose master nodes via environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -456,6 +456,7 @@ set -o errexit -o nounset -o pipefail -o xtrace
 source /opt/mesosphere/environment.export
 source /opt/mesosphere/active/dcos-integration-test/util/test_env.export || true # old location
 source /opt/mesosphere/active/dcos-integration-test/test_env.export || true # old location
+export MASTER_HOSTS='$(subst ${space},${comma},$(MASTER_IPS))'
 export SLAVE_HOSTS='$(subst ${space},${comma},$(AGENT_IPS))'
 export PUBLIC_SLAVE_HOSTS='$(subst ${space},${comma},$(PUBLIC_AGENT_IPS))'
 cd '$(DCOS_PYTEST_DIR)'


### PR DESCRIPTION
Setting these hosts is necessary for running the integration tests for Enterprise DC/OS

See https://jira.mesosphere.com/browse/DCOS-17636

To recreate the issue described on JIRA on `master`, I ran the following command:

```
make \
  DOCKER_VERSION=1.13.1 \
  MESOS_SYSTEMD_ENABLE_SUPPORT=false \
  DCOS_GENERATE_CONFIG_PATH=/tmp/dcos_generate_config.ee.sh \
  DCOS_PYTEST_CMD='export DCOS_LOGIN_UNAME=admin && \
		   export DCOS_LOGIN_PW=admin && \
		   pytest' \
  test
```

The issue is not present with this branch.