### PR TITLE
Rename py.test to pytest.

### DIFF
--- a/ci/test-e2e.sh
+++ b/ci/test-e2e.sh
@@ -78,7 +78,7 @@ if [[ -n "${TEAMCITY_VERSION}" ]]; then
 fi
 # Configure integration tests
 tee >> make-config.mk << EOM
-DCOS_PYTEST_CMD := py.test ${TEST_ARGS}
+DCOS_PYTEST_CMD := pytest ${TEST_ARGS}
 EOM
 
 # Deploy

--- a/ci/test-integration.sh
+++ b/ci/test-integration.sh
@@ -67,7 +67,7 @@ if [[ -n "${TEAMCITY_VERSION:-}" ]]; then
 fi
 # Configure integration tests
 tee >> make-config.mk << EOM
-DCOS_PYTEST_CMD := py.test ${TEST_ARGS}
+DCOS_PYTEST_CMD := pytest ${TEST_ARGS}
 EOM
 
 # Deploy

--- a/make-defaults.mk
+++ b/make-defaults.mk
@@ -48,7 +48,7 @@ DOCKER_IMAGE := mesosphere/dcos-docker
 
 # Test directory and command (make test)
 DCOS_PYTEST_DIR := /opt/mesosphere/active/dcos-integration-test/
-DCOS_PYTEST_CMD := py.test -vv
+DCOS_PYTEST_CMD := pytest -vv
 
 # Variable for the registry host
 REGISTRY_HOST := registry.local


### PR DESCRIPTION
pytest project recommends pytest entry point over py.test. (pytest-dev/pytest#1629, pytest-dev/pytest#1633)