### PR TITLE
Make Admin Router postflight avoid using HTTP call for /

### DIFF
--- a/include.src/sbin/dcos-postflight
+++ b/include.src/sbin/dcos-postflight
@@ -138,6 +138,13 @@ else
   exit 1
 fi
 TARGET="dcos-adminrouter"
-CMD="curl --insecure --fail --location --silent http://127.0.0.1:${API_PORT}/"
-STATUS_CMD="curl --insecure --fail --location --silent -o /dev/null -w "%{http_code}" http://127.0.0.1:${API_PORT}/"
+if [[ -e "/opt/mesosphere/bin/dcos-diagnostics" ]]; then
+    # DC/OS >= 1.10
+    READINESS_CHECK_PATH=/dcos-metadata/dcos-version.json
+else
+    # DC/OS <= 1.9
+    READINESS_CHECK_PATH=/
+fi
+CMD="curl --insecure --fail --location --silent http://127.0.0.1:${API_PORT}${READINESS_CHECK_PATH}"
+STATUS_CMD="curl --insecure --fail --location --silent -o /dev/null -w "%{http_code}" http://127.0.0.1:${API_PORT}${READINESS_CHECK_PATH}"
 await


### PR DESCRIPTION
## High-level description

Up until https://github.com/dcos/dcos/pull/2154 Agent AR was serving the root location (i.e. `/`), even though it is incorrect - it should be returning 404.

Now that it has been fixed, a new endpoint needs to be used for AR pooling which is suitable for both Open and EE, Agent and Master. Such an endpoint seems to be `/dcos-metadata/dcos-version.json`.

## Corresponding DC/OS tickets (obligatory)

* https://jira.mesosphere.com/browse/DCOS-19534 `Agent Admin Router: do not serve root location (respond 404)`

## Related PRs

Open DC/OS PR: https://github.com/dcos/dcos/pull/2154
EE DC/OS PR: https://github.com/mesosphere/dcos-enterprise/pull/1806

**We will most probably need to adjust integration tests for `1.10` and `master` as well, but I do not know how it can be done.**
