### PR TITLE
Add fault_domain_enabled:false to the extra genconf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -460,7 +460,11 @@ endef
 
 # EXTRA_GENCONF_CONFIG is a way to add extra config parameters in scripts
 # calling out dcos-docker.
-EXTRA_GENCONF_CONFIG :=
+define EXTRA_GENCONF_CONFIG_DEFAULT
+fault_domain_enabled: false
+endef
+EXTRA_GENCONF_CONFIG := $(EXTRA_GENCONF_CONFIG_DEFAULT)
+
 define CONFIG_BODY
 ---
 agent_list:


### PR DESCRIPTION
This enables dcos-docker to run on 1.11 EE builds that
require this variable in the config.yaml to disable
the fault domain feature.