### PR TITLE
Revert "Disable fault_domains support."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,6 @@ master_discovery: static
 master_list:
 - $(subst ${space},${newline} ,$(MASTER_IPS))
 process_timeout: 10000
-fault_domain_enabled: false
 resolvers:
 - $(subst ${space},${newline} ,$(RESOLVERS))
 ssh_port: 22


### PR DESCRIPTION
Reverts dcos/dcos-docker#66

fault_domain_enabled cannot be used in OSS DC/OS, the set of integration tests relies on
dcos-docker. We should implement a proper mechanism to distinguish OSS vs EE config.yaml for dcos-docker
https://mesosphere.slack.com/archives/C1JEED22F/p1513383301000081
