### PR TITLE
Add support for new DC/OS Enterprise 1.11 license key config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -489,6 +489,7 @@ define ENTERPRISE_CONFIG_BODY
 superuser_password_hash: $(SUPERUSER_PASSWORD_HASH)
 superuser_username: $(SUPERUSER_USERNAME)
 $(if $(call test_version,$(dcos_version_semver),-ge,1.11.0),fault_domain_enabled: false,)
+$(if $(call test_version,$(dcos_version_semver),-ge,1.11.0),license_key_contents: "$(LICENSE_KEY)",)
 endef
 
 # Shell script that compares two versions.

--- a/configure
+++ b/configure
@@ -388,6 +388,9 @@ DCOS_VARIANT="$(echo "${DCOS_VERSION_META}" | grep 'variant' | cut -d ':' -f 2 |
 echo "Version: ${DCOS_VERSION}"
 echo "Variant: ${DCOS_VARIANT:-oss}"
 
+# Strip suffix, if present, and add patch version segment, if missing.
+DCOS_VERSION_SEMVER="$(echo "${DCOS_VERSION}" | sed -e 's/-.*$//' -e 's/^\([^.]*\.[^.]*\)$/\1.0/')"
+
 echo
 echo "Detecting Docker server version..."
 DOCKER_SERVER_VERSION="$(docker_server_version)"
@@ -570,6 +573,23 @@ if [[ "${DCOS_VARIANT}" == "ee" ]]; then
       exit 2
     fi
   fi
+
+  if vendor/semver_bash/testver.sh "${DCOS_VERSION_SEMVER}" -ge "1.11.0"; then
+    while true; do
+      echo
+      LICENSE_KEY_PATH="${PWD}/license.txt"
+      prompt_custom "Enter license key absolute file path" "LICENSE_KEY_PATH"
+      if [[ -f "${LICENSE_KEY_PATH}" ]]; then
+        break
+      fi
+      if [[ "${AUTO_DEFAULTS:-}" == 'true' ]]; then
+        echo >&2 "License key not found."
+        exit 2
+      else
+        echo "License key not found."
+      fi
+    done
+  fi
 fi
 
 echo
@@ -591,6 +611,11 @@ if [[ "${DCOS_VARIANT}" == "ee" ]]; then
 SUPERUSER_USERNAME := ${SUPERUSER_USERNAME}
 SUPERUSER_PASSWORD_HASH := $(escape_for_makefile "${SUPERUSER_PASSWORD_HASH}")
 EOM
+  if [[ -n "${LICENSE_KEY_PATH:-}" ]]; then
+    cat >> "${CONFIG_PATH}" << EOM
+LICENSE_KEY := $(escape_for_makefile "$(cat "${LICENSE_KEY_PATH}" | sed -e 's/[[:space:]]*$//')")
+EOM
+  fi
 fi
 cat "${CONFIG_PATH}"
 

--- a/make-defaults.mk
+++ b/make-defaults.mk
@@ -78,3 +78,6 @@ SUPERUSER_USERNAME := admin
 # The password hash here is escaped.
 # See https://stackoverflow.com/a/7860705 for details on escaping Makefile variables.
 SUPERUSER_PASSWORD_HASH := $$6$$rounds=656000$$5hVo9bKXfWRg1OCd$$3X2U4hI6RYvKFqm6hXtEeqnH2xE3XUJYiiQ/ykKlDXUie/0B6cuCZEfLe.dN/7jF5mx/vSkoLE5d1Zno20Z7Q0
+
+# A valid license key (file contents, not path)
+LICENSE_KEY :=


### PR DESCRIPTION
Options:
- Set `LICENSE_KEY` (file contents)  in `make-config.mk`
- Use `./configure --auto` to read from `./license.txt`
- Use `./configure` and supply a different license path when prompted