### PR TITLE
Enable CoreOS to work by selecting the right `ip` script

### DIFF
--- a/genconf.src/ip-detect
+++ b/genconf.src/ip-detect
@@ -1,2 +1,8 @@
 #!/bin/bash -e
-/sbin/ip -4 -o addr show dev eth0 | awk '{split($4,a,"/");print a[1]}'
+if [ -f /sbin/ip ]; then
+   IP_CMD=/sbin/ip
+else
+   IP_CMD=/bin/ip
+fi
+
+$IP_CMD -4 -o addr show dev eth0 | awk '{split($4,a,"/");print a[1]}'


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS_OSS-2125 - DC/OS Docker - ip_detect script does not work on CoreOS

With this change, a CoreOS cluster starts up on both DC/OS OSS master and DC/OS Enterprise master.

A CentOS cluster still starts up on both DC/OS OSS master and DC/OS Enterprise master.