### PR TITLE
Use the right variable for seq iteration.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,9 @@ postflight: ## Polls DC/OS until it is healthy (5m timeout)
 	$(foreach NUM,$(shell [[ $(MASTERS) == 0 ]] || seq 1 1 $(MASTERS)),$(call postflight_container,$(MASTER_CTR),$(NUM)))
 	@echo "+ DC/OS Healthy (Master Nodes)"
 	@echo "+ Checking agent nodes"
-	$(foreach NUM,$(shell [[ $(AGENTS) == 0 ]] || seq 1 1 $(MASTERS)),$(call postflight_container,$(AGENT_CTR),$(NUM)))
+	$(foreach NUM,$(shell [[ $(AGENTS) == 0 ]] || seq 1 1 $(AGENTS)),$(call postflight_container,$(AGENT_CTR),$(NUM)))
 	@echo "+ Checking public agent nodes"
-	$(foreach NUM,$(shell [[ $(PUBLIC_AGENTS) == 0 ]] || seq 1 1 $(MASTERS)),$(call postflight_container,$(PUBLIC_AGENT_CTR),$(NUM)))
+	$(foreach NUM,$(shell [[ $(PUBLIC_AGENTS) == 0 ]] || seq 1 1 $(PUBLIC_AGENTS)),$(call postflight_container,$(PUBLIC_AGENT_CTR),$(NUM)))
 	@echo "+ DC/OS Healthy (All Nodes)"
 
 master: $(BOOTSTRAP_GENCONF_PATH) ## Starts the containers for DC/OS masters.


### PR DESCRIPTION
Because it was previously using $(MASTERS), if you had three
master nodes and one agent (public or private), it would attempt
to perform a postflight check for three agents, which would fail.

This change uses $(AGENTS) and $(PUBLIC_AGENTS) for the private
and public agent iterations, respectively.