### PR TITLE
Update distribution Dockerfiles.

### DIFF
--- a/build/base/debian-jessie/Dockerfile
+++ b/build/base/debian-jessie/Dockerfile
@@ -49,6 +49,12 @@ done \
 && rm -f /lib/systemd/system/basic.target.wants/* \
 && rm -f /lib/systemd/system/graphical.target.wants/* \
 && ln -vf /lib/systemd/system/multi-user.target /lib/systemd/system/default.target
+RUN ln -s /bin/mkdir /usr/bin/mkdir
+RUN ln -s /bin/ln /usr/bin/ln
+RUN ln -s /bin/tar /usr/bin/tar
+RUN ln -s /usr/sbin/useradd /usr/bin/useradd
+RUN ln -s /usr/sbin/groupadd /usr/bin/groupadd
+RUN ln -s /bin/systemd-tmpfiles /usr/bin/systemd-tmpfiles
 
 COPY include/systemd/systemd-journald-init.service /lib/systemd/system/
 RUN systemctl enable systemd-journald-init.service || true

--- a/build/base/fedora-23/Dockerfile
+++ b/build/base/fedora-23/Dockerfile
@@ -10,6 +10,7 @@ RUN dnf install -y \
 		btrfs-progs \
 		ca-certificates \
 		curl \
+		findutils \
 		git \
 		iproute \
 		ipset \
@@ -21,6 +22,7 @@ RUN dnf install -y \
 		net-tools \
 		openssh-clients \
 		openssh-server \
+		procps-ng \
 		sudo \
 		systemd \
 		tar \

--- a/build/base/generate.sh
+++ b/build/base/generate.sh
@@ -85,6 +85,8 @@ for version in "${versions[@]}"; do
 
 	if [[ "$distro" == "fedora" ]]; then
 		packages=( "${packages[@]/openssh-client/openssh-clients}" )
+		packages+=( findutils )
+		packages+=( procps-ng )
 	fi
 
 	# normalize array: strip duplicate spaces; trim spaces; remove blank lines; spaces to linebreaks

--- a/build/base/generate.sh
+++ b/build/base/generate.sh
@@ -135,6 +135,19 @@ for version in "${versions[@]}"; do
 		EOF
 	fi
 
+	# set up links for the distros that need 'em
+	case "$distro" in
+		debian|ubuntu)
+			echo "RUN ln -s /bin/mkdir /usr/bin/mkdir" >> "$version/Dockerfile"
+			echo "RUN ln -s /bin/ln /usr/bin/ln" >> "$version/Dockerfile"
+			echo "RUN ln -s /bin/tar /usr/bin/tar" >> "$version/Dockerfile"
+			echo "RUN ln -s /usr/sbin/useradd /usr/bin/useradd" >> "$version/Dockerfile"
+			echo "RUN ln -s /usr/sbin/groupadd /usr/bin/groupadd" >> "$version/Dockerfile"
+			echo "RUN ln -s /bin/systemd-tmpfiles /usr/bin/systemd-tmpfiles" >> "$version/Dockerfile"
+			;;
+		*) ;;
+	esac
+
 	cat >> "$version/Dockerfile" <<-'EOF'
 
 	COPY include/systemd/systemd-journald-init.service /lib/systemd/system/

--- a/build/base/ubuntu-xenial/Dockerfile
+++ b/build/base/ubuntu-xenial/Dockerfile
@@ -49,6 +49,12 @@ done \
 && rm -f /lib/systemd/system/basic.target.wants/* \
 && rm -f /lib/systemd/system/graphical.target.wants/* \
 && ln -vf /lib/systemd/system/multi-user.target /lib/systemd/system/default.target
+RUN ln -s /bin/mkdir /usr/bin/mkdir
+RUN ln -s /bin/ln /usr/bin/ln
+RUN ln -s /bin/tar /usr/bin/tar
+RUN ln -s /usr/sbin/useradd /usr/bin/useradd
+RUN ln -s /usr/sbin/groupadd /usr/bin/groupadd
+RUN ln -s /bin/systemd-tmpfiles /usr/bin/systemd-tmpfiles
 
 COPY include/systemd/systemd-journald-init.service /lib/systemd/system/
 RUN systemctl enable systemd-journald-init.service || true


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-20806

The Dockerfiles for fedora, ubuntu, debian, and centos were having issues trying to install and run DC/OS using dcos-docker.  I went through each one of these distributions and found the missing utilities and path issues, and used those to update `generate.sh`, which in turn generates each of the distribution Dockerfiles.

Using latest master on both open and enterprise, I was able to boot a one master, two agent (pub/priv) cluster and install packages from the universe.

I ran into some weird issues with some files being corrupted periodically, causing DC/OS to not start successfully (invalid config files, jar files, etc), but I believe that to be a separate issue.  This pull request simply addresses the Dockerfiles so that dcos-docker can run DC/OS on those various distributions.